### PR TITLE
skip upload if file exists

### DIFF
--- a/lib/static_sync/config.rb
+++ b/lib/static_sync/config.rb
@@ -43,6 +43,10 @@ module StaticSync
       conflict_mode == 'fail_if_cached'
     end
 
+    def ignore_conflict?
+      conflict_mode == 'ignore_conflict'
+    end
+
     def load(path = '.static')
       content = '{}'
       begin

--- a/lib/static_sync/processor.rb
+++ b/lib/static_sync/processor.rb
@@ -12,6 +12,7 @@ module StaticSync
     def initialize(config, storage = nil)
       @config  = config
       @storage = storage || StaticSync::Storage.new(config)
+      @skip    = false
     end
 
     def sync
@@ -27,7 +28,7 @@ module StaticSync
               log.info("Uploading #{file}") if @config.log
             end
             begin
-              @storage.create(current_file.headers)
+              @storage.create(current_file.headers) unless @skip
             rescue => error
               log.error("Failed to upload #{file}")
               raise error
@@ -46,7 +47,8 @@ module StaticSync
         if file.cached?
           raise ConflictError, "modifications to existing cached files are not allowed."
         end
-      else
+      elsif @config.ignore_conflict?
+        @skip = true
         log.info("#{file} already exist, skipping.") if @config.log
       end
     end

--- a/lib/static_sync/processor.rb
+++ b/lib/static_sync/processor.rb
@@ -12,7 +12,7 @@ module StaticSync
     def initialize(config, storage = nil)
       @config  = config
       @storage = storage || StaticSync::Storage.new(config)
-      @skip    = false
+      @skip    = []
     end
 
     def sync
@@ -28,7 +28,7 @@ module StaticSync
               log.info("Uploading #{file}") if @config.log
             end
             begin
-              @storage.create(current_file.headers) unless @skip
+              @storage.create(current_file.headers) unless skip(file)
             rescue => error
               log.error("Failed to upload #{file}")
               raise error
@@ -48,9 +48,13 @@ module StaticSync
           raise ConflictError, "modifications to existing cached files are not allowed."
         end
       elsif @config.ignore_conflict?
-        @skip = true
+        @skip << file
         log.info("#{file} already exist, skipping.") if @config.log
       end
+    end
+
+    def skip(file)
+      @skip.include?(file)
     end
 
     def local_filtered_files

--- a/lib/static_sync/processor.rb
+++ b/lib/static_sync/processor.rb
@@ -46,6 +46,8 @@ module StaticSync
         if file.cached?
           raise ConflictError, "modifications to existing cached files are not allowed."
         end
+      else
+        log.info("#{file} already exist, skipping.") if @config.log
       end
     end
 

--- a/spec/processor_spec.rb
+++ b/spec/processor_spec.rb
@@ -12,14 +12,42 @@ describe StaticSync::Processor do
     })
   end
 
-  let(:storage) { stub }
+  let(:storage) { double }
 
   subject do
     StaticSync::Processor.new(config, storage)
   end
 
+  describe '#sync' do
+    let(:storage) { double(has_version?: false ) }
+
+    after { subject.sync }
+
+    context 'when a file has a conflict and the config is ignoring them' do
+      before do
+        allow(storage).to receive(:has_file?).and_return(true)
+        allow(config).to receive(:ignore_conflict?).and_return(true)
+      end
+
+      it 'skips the uploading' do
+        expect(storage).not_to receive(:create)
+      end
+    end
+
+    context 'when a file has a conflict and the does not ignoring them' do
+      before do
+        allow(storage).to receive(:has_file?).and_return(true)
+        allow(config).to receive(:ignore_conflict?).and_return(false)
+      end
+
+      it 'uploads the file' do
+        expect(storage).to receive(:create).at_least(:once)
+      end
+    end
+  end
+
   describe "#handle_conflict" do
-    let(:file) { stub }
+    let(:file) { double }
 
     context "when in overwrite mode" do
       let(:config) do
@@ -48,7 +76,7 @@ describe StaticSync::Processor do
     end
 
     context "when in fail on cache mode" do
-      let(:file) { stub(:cached? => false) }
+      let(:file) { double(:cached? => false) }
 
       let(:config) do
         StaticSync::Config.new.merge({
@@ -61,7 +89,7 @@ describe StaticSync::Processor do
       end
 
       context "when the file is cached" do
-        let(:file) { stub(:cached? => true) }
+        let(:file) { double(:cached? => true) }
 
         it "raises a conflict error" do
           expect {

--- a/spec/storage_cache_spec.rb
+++ b/spec/storage_cache_spec.rb
@@ -17,8 +17,8 @@ module StaticSync
     describe "#has_file?" do
 
       it "returns false by default" do
-        subject.has_file?(version_one).should be_false
-        subject.has_file?(version_two).should be_false
+        subject.has_file?(version_one).should be false
+        subject.has_file?(version_two).should be false
       end
 
       context "when an existing version of a file exists in the cache" do
@@ -26,7 +26,7 @@ module StaticSync
         let(:files) { [version_one] }
 
         it "returns true if the given version is the same" do
-          subject.has_file?(version_one).should be_true
+          subject.has_file?(version_one).should be true
         end
       end
     end
@@ -34,8 +34,8 @@ module StaticSync
     describe "#has_version?" do
 
       it "returns false by default" do
-        subject.has_version?(version_one).should be_false
-        subject.has_version?(version_two).should be_false
+        subject.has_version?(version_one).should be false
+        subject.has_version?(version_two).should be false
       end
 
       context "when an existing version of a file exists in the cache" do
@@ -43,11 +43,11 @@ module StaticSync
         let(:files) { [version_one] }
 
         it "returns false if the given version is different" do
-          subject.has_version?(version_two).should be_false
+          subject.has_version?(version_two).should be false
         end
 
         it "returns true if the given version is the same" do
-          subject.has_version?(version_one).should be_true
+          subject.has_version?(version_one).should be true
         end
       end
     end
@@ -55,8 +55,8 @@ module StaticSync
     describe "#has_conflict?" do
 
       it "returns false by default" do
-        subject.has_conflict?(version_one).should be_false
-        subject.has_conflict?(version_two).should be_false
+        subject.has_conflict?(version_one).should be false
+        subject.has_conflict?(version_two).should be false
       end
 
       context "when an existing version of a file exists in the cache" do
@@ -64,11 +64,11 @@ module StaticSync
         let(:files) { [version_one] }
 
         it "returns false when the given version is the same" do
-          subject.has_conflict?(version_one).should be_false
+          subject.has_conflict?(version_one).should be false
         end
 
         it "returns true when the given version is different" do
-          subject.has_conflict?(version_two).should be_true
+          subject.has_conflict?(version_two).should be true
         end
 
       end

--- a/spec/uploadable_spec.rb
+++ b/spec/uploadable_spec.rb
@@ -16,7 +16,7 @@ describe StaticSync::Uploadable do
   describe "#headers" do
 
     it "should make all files viewable by everyone" do
-      html_file.headers[:public].should be_true
+      html_file.headers[:public].should be true
     end
 
     it "should reduce storage costs for all files" do
@@ -70,7 +70,7 @@ describe StaticSync::Uploadable do
 
   describe "#cached?" do
     it "returns false by default" do
-      subject.cached?.should be_false
+      subject.cached?.should be false
     end
 
     context "when caching is enabled for html" do
@@ -80,7 +80,7 @@ describe StaticSync::Uploadable do
       end
 
       it "returns true for a html file" do
-        html_file.cached?.should be_true
+        html_file.cached?.should be true
       end
     end
   end
@@ -137,11 +137,11 @@ describe StaticSync::Uploadable do
   describe "#gzipped?" do
 
     xit "returns true for html files" do
-      html_file.gzipped?.should be_true
+      html_file.gzipped?.should be true
     end
 
     it "returns false for png files" do
-      png_file.gzipped?.should be_false
+      png_file.gzipped?.should be false
     end
 
   end

--- a/static_sync.gemspec
+++ b/static_sync.gemspec
@@ -18,7 +18,8 @@ Gem::Specification.new do |gem|
   gem.has_rdoc      = false
 
   gem.add_dependency("fog", [">= 1.5.0"])
+  gem.add_dependency("mime-types", [">= 3.0"])
 
-  gem.add_development_dependency('rspec')
+  gem.add_development_dependency('rspec', '~> 3.4')
   gem.add_development_dependency('timecop')
 end


### PR DESCRIPTION
This pull request trying to fix the deployment issue we have while syncing assets to production s3 bucket.

Currently it's failing because we have conflict while uploading and conflict is not handled at the moment.

This fix simply skip the upload if there's conflict instead of raise an error.