### PR TITLE
Remove mime-types V3 constraint

### DIFF
--- a/static_sync.gemspec
+++ b/static_sync.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |gem|
   gem.has_rdoc      = false
 
   gem.add_dependency("fog", [">= 1.5.0"])
-  gem.add_dependency("mime-types", [">= 3.0"])
+  gem.add_dependency("mime-types")
 
   gem.add_development_dependency('rspec', '~> 3.4')
   gem.add_development_dependency('timecop')


### PR DESCRIPTION
To be compatible with Rails 3.2 applications.

Specs pass against mime-types v1.25.1.