### PR TITLE
only log file.path instead of the whole file object

### DIFF
--- a/lib/static_sync/processor.rb
+++ b/lib/static_sync/processor.rb
@@ -56,7 +56,7 @@ module StaticSync
       if @storage.has_file?(file.version)
         handle_conflict(file)
       else
-        log.info("Uploading #{ file }") if @config.log
+        log.info("Uploading #{ file.path }") if @config.log
       end
     end
 


### PR DESCRIPTION
### Context

Stop static_sync from showing the whole file object when uploading.

```
Uploading #<struct StaticSync::Uploadable path="webpack/app-ee0eadb377c4727eaa43.js", config={"local"=>{"directory"=>"public"}, "remote"=>{"provider"=>"AWS", "region"=>"ap-southeast-2", "username"=>"xxxxxxxxxxxxxxxxxxxxxxxxx", 
"password"=>"xxxxxxxxxxxxxxxxxxxxxxxxxx=", "directory"=>"assets.envato-static.com", "path_style"=>true}, "cache"=>{"javascript"=>315360000, "css"=>315360000, "image"=>315360000, "font-woff"=>315360000, "x-font-truetype"=>315360000, "vnd.ms-fontobject"=>315360000}, "ignored"=>"(gz|psd|scss|manifest.yml|manifest.json)$", "conflict_mode"=>"ignore_conflict"}>
```

To `file.path`.
